### PR TITLE
Use the batch option to gpg command, use long GPG key

### DIFF
--- a/run.py
+++ b/run.py
@@ -17,7 +17,7 @@ except Exception:
     raise
 
 GH_BASE_URL = "https://api.github.com/repos/OpenObservatory/lepidopter-update"
-GPG_KEY_ID = "204F9D29"
+GPG_KEY_ID = "0xC3ECDC04204F9D29"
 
 def _get_latest_release_tag():
     params = {
@@ -156,7 +156,7 @@ def update(args):
         print("Update file does not exist. Will not update.")
         return
 
-    call(["gpg", "-u", GPG_KEY_ID, "-a", "-b", update_file])
+    call(["gpg", "--batch", "-u", GPG_KEY_ID, "-a", "-b", update_file])
 
     repo = git.Repo(CWD)
     repo.git.add("updater/versions/")

--- a/updater/updater.py
+++ b/updater/updater.py
@@ -66,12 +66,13 @@ def verify_file(signature_path, signer_pk_path):
 
     try:
         try:
-            check_call(["gpg", "--yes", "-o", tmp_key, "--dearmor", signer_pk_path])
+            check_call(["gpg", "--batch", "--yes", "-o", tmp_key,
+                        "--dearmor", signer_pk_path])
         except CalledProcessError:
             raise InvalidPublicKey
 
         try:
-            output = check_output(["gpg", "--status-fd", "1",
+            output = check_output(["gpg", "--batch", "--status-fd", "1",
                                    "--no-default-keyring", "--keyring",
                                    tmp_key, "--trust-model", "always",
                                    "--verify", signature_path])


### PR DESCRIPTION
- Change to long GPG key id to avoid collision attacks.
- Use batch option to avoid gpg trying to find a matching data file by
  stripping certain suffixes
