### PR TITLE
Fix remove specific files from /etc/ooniprobe/, add notes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,3 +14,5 @@ If the current version is < the latest version, we will download all the update
 scripts up until the latest and execute them in order to ensure a consistent
 update.
 
+**Note**: The version file must not be terminated by a newline.
+

--- a/updater/versions/update-1.py
+++ b/updater/versions/update-1.py
@@ -212,7 +212,9 @@ def run():
     rm_rf("/etc/cron.daily/tor")
     rm_rf("/etc/cron.daily/update_ooniprobe")
 
-    rm_rf("/etc/ooniprobe/")
+    rm_rf("/etc/ooniprobe/ooniprobe.conf")
+    rm_rf("/etc/ooniprobe/oonireport.conf")
+    rm_rf("/etc/ooniprobe/oonideckconfig")
 
     rm_rf("/opt/ooni/remove-inc-reports.sh")
     rm_rf("/opt/ooni/remove-upl-reports.sh")


### PR DESCRIPTION
- Add notes about version file handling.
- The script remove_old_logs requires ooniconfig.sh located in
  /etc/ooniprobe/.
